### PR TITLE
fix start of cc2420: avoid infintie wait for stable oscillator interrupt

### DIFF
--- a/tools/platforms/msp430/pybsl/tos-bsl.in
+++ b/tools/platforms/msp430/pybsl/tos-bsl.in
@@ -1342,7 +1342,10 @@ class BootStrapLoader(LowLevel):
         self.bslTxRx(self.BSL_CHANGEBAUD,   #Command: change baudrate
                     a, l)                   #args are coded in adr and len
         time.sleep(0.010)                   #recomended delay
-        self.serialport.setBaudrate(baudrate)
+        try:
+            self.serialport.setBaudrate(baudrate)
+        except AttributeError:
+            self.serialport.baudrate = baudrate
 
     def actionReadBSLVersion(self):
         """informational output of BSL version number.

--- a/tools/platforms/msp430/pybsl/tos-bsl.in
+++ b/tools/platforms/msp430/pybsl/tos-bsl.in
@@ -1524,7 +1524,7 @@ def hexify(line, bytes, width=16):
         )
 
 #Main:
-def main(itest=1):
+def main():
     global DEBUG
     import getopt
     filetype    = None
@@ -1547,9 +1547,6 @@ def main(itest=1):
     forceBSL    = 0
     dumpivt     = 0
     dumpinfo    = 0
-    
-    bsl.invertRST = 1
-    bsl.invertTEST = itest
     
     if comPort is None and os.environ.get("GOODFET")!=None:
         glob_list = glob.glob(os.environ.get("GOODFET"));
@@ -1904,7 +1901,7 @@ def main(itest=1):
 
 if __name__ == '__main__':
     try:
-        main(1)
+        main()
     except SystemExit:
         raise               #let pass exit() calls
     except KeyboardInterrupt:
@@ -1913,7 +1910,7 @@ if __name__ == '__main__':
         sys.exit(1)         #set errorlevel for script usage
     except Exception, msg:  #every Exception is caught and displayed
         if DEBUG: raise     #show full trace in debug mode
-        #sys.stderr.write("\nAn error occoured:\n%s\n" % msg) #short messy in user mode
-        #sys.exit(1)         #set errorlevel for script usage
-        main(0);
+        sys.stderr.write("\nAn error occoured:\n%s\n" % msg) #short messy in user mode
+        sys.exit(1)         #set errorlevel for script usage
+
 

--- a/tos/chips/cc2420/CC2420.h
+++ b/tos/chips/cc2420/CC2420.h
@@ -190,6 +190,7 @@ enum {
 enum cc2420_enums {
   CC2420_TIME_ACK_TURNAROUND = 7, // jiffies
   CC2420_TIME_VREN = 20,          // jiffies
+  CC2420_TIME_OSC = 64,           // jiffies, about 2ms = double respect datasheet
   CC2420_TIME_SYMBOL = 2,         // 2 symbols / jiffy
   CC2420_BACKOFF_PERIOD = ( 20 / CC2420_TIME_SYMBOL ), // symbols
   CC2420_MIN_BACKOFF = ( 20 / CC2420_TIME_SYMBOL ),  // platform specific?

--- a/tos/chips/cc2420/control/CC2420ControlC.nc
+++ b/tos/chips/cc2420/control/CC2420ControlC.nc
@@ -86,6 +86,7 @@ implementation {
   CC2420ControlP.RXCTRL1 -> Spi.RXCTRL1;
   CC2420ControlP.RSSI  -> Spi.RSSI;
   CC2420ControlP.TXCTRL  -> Spi.TXCTRL;
+  CC2420ControlP.SNOP -> Spi.SNOP;
 
   components new CC2420SpiC() as SyncSpiC;
   CC2420ControlP.SyncResource -> SyncSpiC;

--- a/tos/chips/cc2420/interfaces/CC2420Power.nc
+++ b/tos/chips/cc2420/interfaces/CC2420Power.nc
@@ -73,7 +73,7 @@ interface CC2420Power {
   /**
    * Signals that the oscillator has been started.
    */
-  async event void startOscillatorDone();
+  async event void startOscillatorDone(error_t err);
 
   /**
    * Stop the oscillator.
@@ -95,5 +95,12 @@ interface CC2420Power {
    * @return SUCCESS if receive mode has been disabled, FAIL otherwise.
    */
   async command error_t rfOff();
+
+  /**
+   * Query if radio is on
+   *
+   * @return TRUE if radio is on, FALSE if is off or in an intermediate state.
+   */
+  async command bool isOn();
 
 }

--- a/tos/chips/cc2420/lpl/DefaultLplP.nc
+++ b/tos/chips/cc2420/lpl/DefaultLplP.nc
@@ -261,7 +261,17 @@ implementation {
           || call SendState.getState() == S_LPL_SENDING) {
         initializeSend();
       }
+      return;
     }
+    /* here radio didn't start for an error, we ask radio on to send, 
+     * so send is not possible, signal with a sendDone fails...
+     */
+    if(!call SendState.isState(S_LPL_NOT_SENDING)) {
+      call SendState.toIdle();
+      call SendDoneTimer.stop();
+      signal Send.sendDone(currentSendMsg, FAIL);
+    }
+    /* we are not sending, not need to signal the radio On fails */
   }
     
   event void SubControl.stopDone(error_t error) {
@@ -270,7 +280,7 @@ implementation {
       if(call SendState.getState() == S_LPL_FIRST_MESSAGE
           || call SendState.getState() == S_LPL_SENDING) {
         // We're in the middle of sending a message; start the radio back up
-        post startRadio();
+	post startRadio();
         
       } else {        
         call OffTimer.stop();

--- a/tos/chips/cc2420/lpl/PowerCycleP.nc
+++ b/tos/chips/cc2420/lpl/PowerCycleP.nc
@@ -194,6 +194,12 @@ implementation {
   
   /***************** SubControl Events ****************/
   event void SubControl.startDone(error_t error) {
+    if(error) {
+      //radio didn't start, retry
+      post startRadio();
+      return;
+    }
+
     call RadioPowerState.forceState(S_ON);
     //call Leds.led2On();
     
@@ -310,5 +316,3 @@ implementation {
   default event void SplitControl.stopDone(error_t error) {
   }
 }
-
-


### PR DESCRIPTION
Hi,
testing an app on a custom platform I found the node stop to send radio message: the problem was the InterrupCCA in CC2420ControlP is never fired like the logical level from radio remains low. This hang the code in an infinite wait of CC2420 oscillator is stable. Also hang the SPI bus so also external memory is not usable.

I don't know why on telosb/tmote platform is not consider CC2420 oscillator can not stabilize, but I think this changes can useful also on that pltaform to handle it.

I add a timeout for the interrupt, using double time reported on CC2420 datasheet. When timeout expire it checks, using a NOP, the status byte to see if oscillator is stable or not: in case it isn't set status on S_VREG_STARTED and signal it fails. 

I also handle error condition in default LPL component:
- in DefaultLpl componet: resignal the error case on sendDone event to signal the message is not sent
- in PowerCycle component: post task to retry to turn on the radio
